### PR TITLE
chore(pay-messenger): add @cryptology.hk/pay-user dependency

### DIFF
--- a/packages/pay-messenger/package.json
+++ b/packages/pay-messenger/package.json
@@ -39,8 +39,9 @@
         "preset": "../../jest-preset.json"
     },
     "dependencies": {
+        "@cryptology.hk/pay-config": "^2.1.0",
+        "@cryptology.hk/pay-user": "^2.1.1",
         "bignumber.js": "^8.1.1",
-        "joi": "^14.3.1",
-        "@cryptology.hk/pay-config": "^2.1.0"
+        "joi": "^14.3.1"
     }
 }


### PR DESCRIPTION
Currently the `yarn setup` command will fail because `@cryptology.hk/pay-messenger` is using `@cryptology.hk/pay-user` but doesn't have it listed as a dependency.