### PR TITLE
fix(pay-currency): access CoinGecko response with lower case currency names

### DIFF
--- a/packages/pay-currency/__tests__/coinGecko.test.ts
+++ b/packages/pay-currency/__tests__/coinGecko.test.ts
@@ -15,11 +15,9 @@ describe("pay-currency: CoinGeckoAPI()", () => {
         });
 
         it("Should return 1 in the TEST environment", async () => {
-            const expectedValue: BigNumber = new BigNumber(1);
-            const currency: string = "ARK";
-            const fiat: string = "USD";
-            const result: BigNumber = await CoinGeckoAPI.getSimplePrice(currency, fiat);
-            expect(result).toEqual(expectedValue);
+            const value: BigNumber = await CoinGeckoAPI.getSimplePrice("ARK", "USD");
+
+            expect(value.isGreaterThan(0)).toBeTrue();
         });
     });
 });

--- a/packages/pay-currency/src/coinGecko.ts
+++ b/packages/pay-currency/src/coinGecko.ts
@@ -35,12 +35,10 @@ export class CoinGeckoAPI {
      * Didn't manage to mock the getter for simple.price in testing, so no coverage for this method.
      */
     public static async getSimplePrice(currency: string, fiat: string): Promise<BigNumber> {
-        if (process.env.NODE_ENV === "test") {
-            // This thing just dont work well with mocks, so yeah...
-            return new BigNumber(1);
-        }
-
         try {
+            currency = currency.toLowerCase();
+            fiat = fiat.toLowerCase();
+
             const simpleCurrencyTicker = await coinGeckoClient.simple.price({
                 ids: [currency],
                 vs_currencies: [fiat],


### PR DESCRIPTION
The `CoinGecko.getSimplePrice` method wasn't working at all which went unnoticed because the tests didn't test the real implementation but returned fake values during tests.

The response contains the currency pairs as lowercase, meaning `{ ark: { btc: 1 } }` will be the response instead of `{ ARK: { BTC: 1 } }` which results in an property access error that causes `new BigNumber(0)` to be returned even though there is a valid response.