### PR TITLE
chore: remove pre-commit script

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     ],
     "husky": {
         "hooks": {
-            "pre-commit": "lint-staged && cross-env-shell ./scripts/pre-commit.sh"
+            "pre-commit": "lint-staged"
         }
     },
     "jest": {

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Running pre-commit script..."
-
-node .circleci/generateConfig.js
-git add .circleci/config.yml
-
-echo "pre-commit script was run succesfully"


### PR DESCRIPTION
The `pre-commit.sh` script causes an error every time you commit something because the `generateConfig.js` doesn't exist so no point in running it.