### PR TITLE
fix(pay-parser): default to currency name if it isn't a symbol

### DIFF
--- a/packages/pay-parser/src/utils.ts
+++ b/packages/pay-parser/src/utils.ts
@@ -257,8 +257,9 @@ export class ParserUtils {
         }
 
         if (amountCurrency !== null) {
+            amountCurrency.currency = CurrencySymbol[amountCurrency.currency] || amountCurrency.currency;
+
             // Convert currency to its current Arktoshi value
-            amountCurrency.currency = CurrencySymbol[amountCurrency.currency];
             amountCurrency.arkToshiValue = await Currency.getExchangedValue(
                 amountCurrency.amount,
                 amountCurrency.currency,


### PR DESCRIPTION
`amountCurrency.currency` is already what `CurrencySymbol[amountCurrency.currency]` and previously `Currency.currencySymbolsToName(amountCurrency.currency)` were supposed to look up.