### PR TITLE
fix(pay-parser): validate address with @arkecosystem/crypto

### DIFF
--- a/packages/pay-parser/__tests__/utils.test.ts
+++ b/packages/pay-parser/__tests__/utils.test.ts
@@ -1216,30 +1216,30 @@ describe("pay-Parser: ParserUtils()", () => {
     });
 
     describe("isValidAddress()", () => {
-        it("should correctly validate an ARK address", async () => {
-            let address: string = "AFrPtEmzu6wdVpa2CnRDEKGQQMWgq8nE9V";
+        it("should correctly validate an ARK address", () => {
+            let address: string = "AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC";
             const token: string = "ARK";
-            let result: boolean = await ParserUtils.isValidAddress(address, token);
+            let result: boolean = ParserUtils.isValidAddress(address, token);
             expect(result).toBeTrue();
             address = "BFrPtEmzu6wdVpa2CnRDEKGQQMWgq8nE9V";
-            result = await ParserUtils.isValidAddress(address, token);
+            result = ParserUtils.isValidAddress(address, token);
             expect(result).toBeFalse();
         });
 
-        it("should correctly validate a DARK address", async () => {
-            let address: string = "DFrPtEmzu6wdVpa2CnRDEKGQQMWgq8nE9V";
+        it("should correctly validate a DARK address", () => {
+            let address: string = "D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib";
             const token: string = "DARK";
-            let result: boolean = await ParserUtils.isValidAddress(address, token);
+            let result: boolean = ParserUtils.isValidAddress(address, token);
             expect(result).toBeTrue();
             address = "BFrPtEmzu6wdVpa2CnRDEKGQQMWgq8nE9V";
-            result = await ParserUtils.isValidAddress(address, token);
+            result = ParserUtils.isValidAddress(address, token);
             expect(result).toBeFalse();
         });
 
-        it("should return false on other addresses", async () => {
+        it("should return false on other addresses", () => {
             const address: string = "DFrPtEmzu6wdVpa2CnRDEKGQQMWgq8nE9V";
             const token: string = "NOTSUPPORTED";
-            const result = await ParserUtils.isValidAddress(address, token);
+            const result = ParserUtils.isValidAddress(address, token);
             expect(result).toBeFalse();
         });
     });

--- a/packages/pay-parser/package.json
+++ b/packages/pay-parser/package.json
@@ -33,12 +33,12 @@
         "preset": "../../jest-preset.json"
     },
     "dependencies": {
+        "@arkecosystem/crypto": "^2.3.23",
         "@cryptology.hk/pay-commands": "^2.1.2",
         "@cryptology.hk/pay-config": "^2.1.0",
         "@cryptology.hk/pay-currency": "^2.1.0",
         "@cryptology.hk/pay-user": "^2.1.1",
-        "bignumber.js": "^9.0.0",
-        "joi": "^14.3.1"
+        "bignumber.js": "^9.0.0"
     },
     "devDependencies": {
         "@types/joi": "^14.3.3"


### PR DESCRIPTION
Perform crypto validation against addresses instead of pseudo-schema validation which verifies any 34-char string as valid.

Before the function did not work at all because it assumed that `Joi.attempt` would throw an error but instead `return !Joi.attempt().error` would have to be used.

_Also includes a fix for when a currency is not registered or retrieved by its name instead of symbol https://github.com/wownmedia/pay/pull/14/files#diff-7a914668a8d3fee6ce03f3339d47aeb2R261._